### PR TITLE
doc: Add French description and translation

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,3 +1,1 @@
 SparkyFitness is a comprehensive fitness tracking and management application designed to help users monitor their nutrition, exercise, and body measurements. It provides tools for daily progress tracking, goal setting, and insightful reports to support a healthy lifestyle.
-
- ❗The upstream license forbids non-commercial use. See [here](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE) for the entire content❗

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,0 +1,2 @@
+SparkyFitness est une application complète de suivi et de gestion de la condition physique conçue pour aider les utilisateurs à surveiller leur nutrition, leurs exercices et leurs mensurations. Elle fournit des outils pour le suivi des progrès quotidiens, la définition d'objectifs et des rapports détaillés pour soutenir un mode de vie sain.
+

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,6 +5,7 @@ packaging_format = 2
 id = "sparkyfitness"
 name = "SparkyFitness"
 description.en = "Track food, fitness, water, and health — together. "
+description.fr = "Suivez votre alimentation, votre forme et votre santé — au même endroit"
 
 version = "0.16.3.3~ynh1"
 


### PR DESCRIPTION
## Problem

The application package was missing French localization for the description and documentation. 
Additionally, the description contained a manual warning about the license which is already handled natively by YunoHost's interface, making it redundant.

## Solution

I added the French translation in `manifest.toml` and created `doc/DESCRIPTION_fr.md`. I also removed the manual license warning string from the description.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

